### PR TITLE
Fix wrong VSYS scaling

### DIFF
--- a/src/adc/mod.rs
+++ b/src/adc/mod.rs
@@ -353,8 +353,8 @@ impl<I2c: embedded_hal_async::i2c::I2c, Delay: embedded_hal_async::delay::DelayN
         let result = ((msb as u16) << 2) | (lsb & 0x03) as u16;
 
         // Convert result to f32
-        // 5.0 is VFSVSYS, the full scale voltage for measuring VSYS.
-        let result = convert_vadc_to_voltage(result, 5.0);
+        // 6.375 is VFSVSYS, the full scale voltage for measuring VSYS.
+        let result = convert_vadc_to_voltage(result, 6.375);
 
         Ok(result)
     }


### PR DESCRIPTION
Full scale voltage for VSYS measurement is 6.375 according to nPM1300 PS v1.2