### PR TITLE
feat: SHIPHOLD and TIMER events

### DIFF
--- a/device.yaml
+++ b/device.yaml
@@ -64,30 +64,42 @@ MAIN:
       type: register
       description: ShipHold pin Events Event Set (W1S)
       address: 0x12
-      size_bits: 1
+      size_bits: 4
       fields:
-        EVENTSHPHLD: { base: uint, start: 0, end: 1, description: Writing 1 sets event }
+        EVENTSHPHLDBTNPRESS: { base: bool, start: 0, end: 1, description: Writing 1 sets event }
+        EVENTSHPHLDBTNRELEASE: { base: bool, start: 1, end: 2, description: Writing 1 sets event }
+        EVENTSHPHLDEXIT: { base: bool, start: 2, end: 3, description: Writing 1 sets event }
+        EVENTWATCHDOGWARN: { base: bool, start: 3, end: 4, description: Writing 1 sets event }
     EVENTSSHPHLDCLR:
       type: register
       description: ShipHold pin Events Event Clear (W1C)
       address: 0x13
-      size_bits: 1
+      size_bits: 4
       fields:
-        EVENTSHPHLD: { base: uint, start: 0, end: 1, description: Writing 1 clears event }
+        EVENTSHPHLDBTNPRESS: { base: bool, start: 0, end: 1, description: Writing 1 clears event }
+        EVENTSHPHLDBTNRELEASE: { base: bool, start: 1, end: 2, description: Writing 1 clears event }
+        EVENTSHPHLDEXIT: { base: bool, start: 2, end: 3, description: Writing 1 clears event }
+        EVENTWATCHDOGWARN: { base: bool, start: 3, end: 4, description: Writing 1 clears event }
     INTENEVENTSSHPHLDSET:
       type: register
       description: ShipHold pin Events Interrupt Enable Set (W1S)
       address: 0x14
-      size_bits: 1
+      size_bits: 4
       fields:
-        EVENTSHPHLD: { base: uint, start: 0, end: 1, description: Writing 1 enables interrupt }
+        EVENTSHPHLDBTNPRESS: { base: bool, start: 0, end: 1, description: Writing 1 enables interrupt }
+        EVENTSHPHLDBTNRELEASE: { base: bool, start: 1, end: 2, description: Writing 1 enables interrupt }
+        EVENTSHPHLDEXIT: { base: bool, start: 2, end: 3, description: Writing 1 enables interrupt }
+        EVENTWATCHDOGWARN: { base: bool, start: 3, end: 4, description: Writing 1 enables interrupt }
     INTENEVENTSSHPHLDCLR:
       type: register
       description: ShipHold pin Events Interrupt Enable Clear (W1C)
       address: 0x15
-      size_bits: 1
+      size_bits: 4
       fields:
-        EVENTSHPHLD: { base: uint, start: 0, end: 1, description: Writing 1 disables interrupt }
+        EVENTSHPHLDBTNPRESS: { base: bool, start: 0, end: 1, description: Writing 1 disables interrupt }
+        EVENTSHPHLDBTNRELEASE: { base: bool, start: 1, end: 2, description: Writing 1 disables interrupt }
+        EVENTSHPHLDEXIT: { base: bool, start: 2, end: 3, description: Writing 1 disables interrupt }
+        EVENTWATCHDOGWARN: { base: bool, start: 3, end: 4, description: Writing 1 disables interrupt }
     EVENTSVBUSIN0SET:
       type: register
       description: VBUSIN Voltage Detection Events Event Set (W1S)

--- a/src/mainreg/mod.rs
+++ b/src/mainreg/mod.rs
@@ -438,4 +438,12 @@ impl<I2c: embedded_hal_async::i2c::I2c, Delay: embedded_hal_async::delay::DelayN
             .write_async(|reg| reg.set_value(mask))
             .await
     }
+
+    pub async fn trigger_sys_reset(&mut self) -> Result<(), crate::NPM1300Error<I2c::Error>> {
+        self.device
+            .main()
+            .tasksysreset()
+            .dispatch_async(|reg| reg.set_tasksysreset(crate::common::Task::Trigger))
+            .await
+    }
 }

--- a/src/mainreg/mod.rs
+++ b/src/mainreg/mod.rs
@@ -270,37 +270,84 @@ impl<I2c: embedded_hal_async::i2c::I2c, Delay: embedded_hal_async::delay::DelayN
             .await
     }
 
-    pub async fn set_shphld_event(&mut self) -> Result<(), crate::NPM1300Error<I2c::Error>> {
+    pub async fn set_shphld_event(
+        &mut self,
+        mask: ShipholdEventMask,
+    ) -> Result<(), crate::NPM1300Error<I2c::Error>> {
         self.device
             .main()
             .eventsshphldset()
-            .write_async(|reg| reg.set_eventshphld(1))
+            .write_async(|reg| {
+                reg.set_eventshphldbtnpress(mask.contains(ShipholdEventMask::BUTTON_PRESSED));
+                reg.set_eventshphldbtnrelease(mask.contains(ShipholdEventMask::BUTTON_RELEASED));
+                reg.set_eventshphldexit(mask.contains(ShipholdEventMask::SHIPHOLD_EXIT));
+                reg.set_eventwatchdogwarn(mask.contains(ShipholdEventMask::WATCHDOG_WARNING));
+            })
             .await
     }
 
-    pub async fn clear_shphld_event(&mut self) -> Result<(), crate::NPM1300Error<I2c::Error>> {
+    pub async fn clear_shphld_event(
+        &mut self,
+        mask: ShipholdEventMask,
+    ) -> Result<(), crate::NPM1300Error<I2c::Error>> {
         self.device
             .main()
             .eventsshphldclr()
-            .write_async(|reg| reg.set_eventshphld(1))
+            .write_async(|reg| {
+                reg.set_eventshphldbtnpress(mask.contains(ShipholdEventMask::BUTTON_PRESSED));
+                reg.set_eventshphldbtnrelease(mask.contains(ShipholdEventMask::BUTTON_RELEASED));
+                reg.set_eventshphldexit(mask.contains(ShipholdEventMask::SHIPHOLD_EXIT));
+                reg.set_eventwatchdogwarn(mask.contains(ShipholdEventMask::WATCHDOG_WARNING));
+            })
             .await
     }
 
-    pub async fn enable_shphld_interrupt(&mut self) -> Result<(), crate::NPM1300Error<I2c::Error>> {
+    pub async fn get_shiphold_events(
+        &mut self,
+    ) -> Result<ShipholdEventMask, crate::NPM1300Error<I2c::Error>> {
+        let reg = self.device.main().eventsshphldclr().read_async().await?;
+
+        let mut mask = ShipholdEventMask::empty();
+        mask.set(ShipholdEventMask::BUTTON_PRESSED, reg.eventshphldbtnpress());
+        mask.set(
+            ShipholdEventMask::BUTTON_RELEASED,
+            reg.eventshphldbtnrelease(),
+        );
+        mask.set(ShipholdEventMask::SHIPHOLD_EXIT, reg.eventshphldexit());
+        mask.set(ShipholdEventMask::WATCHDOG_WARNING, reg.eventwatchdogwarn());
+
+        Ok(mask)
+    }
+
+    pub async fn enable_shphld_interrupt(
+        &mut self,
+        mask: ShipholdEventMask,
+    ) -> Result<(), crate::NPM1300Error<I2c::Error>> {
         self.device
             .main()
             .inteneventsshphldset()
-            .write_async(|reg| reg.set_eventshphld(1))
+            .write_async(|reg| {
+                reg.set_eventshphldbtnpress(mask.contains(ShipholdEventMask::BUTTON_PRESSED));
+                reg.set_eventshphldbtnrelease(mask.contains(ShipholdEventMask::BUTTON_RELEASED));
+                reg.set_eventshphldexit(mask.contains(ShipholdEventMask::SHIPHOLD_EXIT));
+                reg.set_eventwatchdogwarn(mask.contains(ShipholdEventMask::WATCHDOG_WARNING));
+            })
             .await
     }
 
     pub async fn disable_shphld_interrupt(
         &mut self,
+        mask: ShipholdEventMask,
     ) -> Result<(), crate::NPM1300Error<I2c::Error>> {
         self.device
             .main()
             .inteneventsshphldclr()
-            .write_async(|reg| reg.set_eventshphld(1))
+            .write_async(|reg| {
+                reg.set_eventshphldbtnpress(mask.contains(ShipholdEventMask::BUTTON_PRESSED));
+                reg.set_eventshphldbtnrelease(mask.contains(ShipholdEventMask::BUTTON_RELEASED));
+                reg.set_eventshphldexit(mask.contains(ShipholdEventMask::SHIPHOLD_EXIT));
+                reg.set_eventwatchdogwarn(mask.contains(ShipholdEventMask::WATCHDOG_WARNING));
+            })
             .await
     }
 

--- a/src/mainreg/types.rs
+++ b/src/mainreg/types.rs
@@ -23,3 +23,12 @@ bitflags! {
         const CC2_STATE_CHANGE           = 1 << 5;
     }
 }
+bitflags! {
+    #[derive(Default)]
+    pub struct ShipholdEventMask: u8 {
+        const BUTTON_PRESSED             = 1 << 0;
+        const BUTTON_RELEASED            = 1 << 1;
+        const SHIPHOLD_EXIT              = 1 << 2;
+        const WATCHDOG_WARNING           = 1 << 3;
+    }
+}


### PR DESCRIPTION
Hi,

Here I have implemented TIMER event (that I just needed) and extended support for SHIPHOLD events (button release, shiphold exit) that lay in the same register.

Code is tested using a nPM1300.

NB: The change is breaking existing API: set/clear_shphld_event(), get_shiphold_events(), enable/disable_disable_shphld_interrupt() take or return ShipholdEventMask: bitmask of the shiphold events. Hope it's ok. If not, please share your opinion how to solve it. 

Cheers,
Dmitry